### PR TITLE
ESP32-S2 support using the built-in USB peripheral

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -129,7 +129,7 @@ build_flags =
 [esp32v2]
 platform = https://github.com/platformio/platform-espressif32.git#feature/arduino-upstream
 platform_packages =
-	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.0
+	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.14
 framework = arduino
 build_flags =
 	-D AR488_CUSTOM
@@ -158,3 +158,18 @@ build_flags =
 	-D DIO5=27 -D DIO6=14 -D DIO7=12  -D DIO8=13
 	-D REN=22  -D IFC=21  -D NDAC=19  -D NRFD=23
 	-D DAV=18  -D EOI=17  -D ATN=16   -D SRQ=4
+
+[env:ar488-esp32s2]
+platform = espressif32
+framework = arduino
+board = esp32-s2-saola-1
+upload_protocol = esptool
+build_flags =
+	${esp32v2.build_flags}
+	-D BOARD_HAS_PSRAM
+	-D AR_ESP32S2_USB_CDC
+	-D AR488_CUSTOM
+	-D DIO1=1 -D DIO2=3 -D DIO3=5  -D DIO4=7
+	-D DIO5=2 -D DIO6=4 -D DIO7=6  -D DIO8=8
+	-D REN=10  -D IFC=14  -D NDAC=13  -D NRFD=12
+	-D DAV=11  -D EOI=9  -D ATN=16   -D SRQ=15

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 src_dir = src/
-default_envs = esp32dev
+default_envs = AR488-ESP32-Rev4
 
 [avr]
 platform = atmelavr
@@ -159,17 +159,32 @@ build_flags =
 	-D REN=22  -D IFC=21  -D NDAC=19  -D NRFD=23
 	-D DAV=18  -D EOI=17  -D ATN=16   -D SRQ=4
 
-[env:ar488-esp32s2]
+[env:AR488-ESP32-Rev4]
 platform = espressif32
 framework = arduino
 board = esp32-s2-saola-1
 upload_protocol = esptool
 build_flags =
 	${esp32v2.build_flags}
-	-D BOARD_HAS_PSRAM
 	-D AR_ESP32S2_USB_CDC
 	-D AR488_CUSTOM
-	-D DIO1=1 -D DIO2=3 -D DIO3=5  -D DIO4=7
-	-D DIO5=2 -D DIO6=4 -D DIO7=6  -D DIO8=8
-	-D REN=10  -D IFC=14  -D NDAC=13  -D NRFD=12
-	-D DAV=11  -D EOI=9  -D ATN=16   -D SRQ=15
+	-D SN7516X -D SN7516X_TE=17
+	-D DIO1=8 -D DIO2=9 -D DIO3=10  -D DIO4=11
+	-D DIO5=12 -D DIO6=13 -D DIO7=14  -D DIO8=15
+	-D REN=26  -D IFC=38  -D NDAC=33  -D NRFD=34
+	-D DAV=40  -D EOI=35  -D ATN=36   -D SRQ=37
+
+[env:AR488-ESP32-Rev5]
+platform = espressif32
+framework = arduino
+board = esp32-s2-saola-1
+upload_protocol = esptool
+build_flags =
+	${esp32v2.build_flags}
+	-D AR_ESP32S2_USB_CDC
+	-D AR488_CUSTOM
+	-D SN7516X -D SN7516X_TE=17 -D SN7516X_DC=38 -D SN7516X_PE=1
+	-D DIO1=8 -D DIO2=9 -D DIO3=10  -D DIO4=11
+	-D DIO5=12 -D DIO6=13 -D DIO7=14  -D DIO8=15
+	-D REN=21  -D IFC=4  -D NDAC=33  -D NRFD=34
+	-D DAV=5  -D EOI=35  -D ATN=36   -D SRQ=37

--- a/src/AR488_Config.h
+++ b/src/AR488_Config.h
@@ -35,15 +35,15 @@
    * section below
    */
   /* Serial ports */
-  #define AR_HW_SERIAL
+//  #define AR_HW_SERIAL
 #ifndef AR_SERIAL_PORT
-  #define AR_SERIAL_PORT Serial
+//  #define AR_SERIAL_PORT Serial
   //#define AR_SERIAL_PORT Serial1
   //#define AR_SERIAL_PORT Serial2
   //#define AR_SERIAL_PORT Serial3
   //#define AR_CDC_SERIAL
   //#define AR_SW_SERIAL
-  #define AR_BT_SERIAL_PORT Serial
+//  #define AR_BT_SERIAL_PORT Serial
 #endif
 
 /*** UNO and NANO boards ***/

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -13,6 +13,11 @@
 
 #endif
 
+#ifdef AR_ESP32S2_USB_CDC
+#include "USB.h"
+USBCDC UsbCdcSerial;
+#endif
+
 /********** BT SERIAL PORT DECLARATIONS **********/
 /* on ESP32, this comes as an extra serial port  */
 /* on Arduino, this is done using an HC05 like   */
@@ -23,6 +28,12 @@ Stream *arSerial = NULL;
 
 Stream* getSerialStream() {
   if (arSerial == NULL) {
+#if defined(AR_ESP32S2_USB_CDC)
+	arSerial =(Stream*) &(UsbCdcSerial);
+	UsbCdcSerial.begin();
+	USB.begin();
+
+#else
 #if defined(AR_CDC_SERIAL)
 	Serial_ *serial = &(AR_SERIAL_PORT);
 #elif defined(AR_HW_SERIAL)
@@ -34,6 +45,8 @@ Stream* getSerialStream() {
 #endif
 	serial->begin(AR_SERIAL_BAUD);
 	arSerial = (Stream*) serial;
+#endif
+
   }
   return arSerial;
 }


### PR DESCRIPTION
This adds support for the ESP32-S2 using the built-in USB peripheral.